### PR TITLE
Fix sed to not capture line and function coverage

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,9 @@ FILTERED_COVERAGE_PATH='./lcov_filtered.info'
 if [ ! -z "$3" ]; then
     echo "Excluding $3 from coverage..."
     lcov --remove ${LCOV_PATH} $3 -o ${FILTERED_COVERAGE_PATH}
-    CODE_COVERAGE=$(lcov --list ${FILTERED_COVERAGE_PATH} | sed -n "s/.*Total:|\(.*\)%.*/\1/p")
+    CODE_COVERAGE=$(lcov --list ${FILTERED_COVERAGE_PATH} | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
 else
-    CODE_COVERAGE=$(lcov --list ${LCOV_PATH} | sed -n "s/.*Total:|\(.*\)%.*/\1/p")
+    CODE_COVERAGE=$(lcov --list ${LCOV_PATH} | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
 fi
 
 echo "Minumum Coverage Required: ${MINIMUM_COVERAGE}%"


### PR DESCRIPTION
I tried using this action but ran into a problem.

Output of `lcov --list`:

```
➜ lcov --list ~/Desktop/cov.txt                                        
Reading tracefile /Users/Steffen/Desktop/cov.txt
                                 |Lines       |Functions  |Branches    
Filename                         |Rate     Num|Rate    Num|Rate     Num
=======================================================================
[/home/runner/work/SwiftBeanCountModel/SwiftBeanCountModel/Sources/SwiftBeanCountModel/]
Account.swift                    |99.3%    136|96.7%    30|    -      0
AccountName.swift                | 100%     50| 100%     9|    -      0
Amount.swift                     | 100%     26| 100%     9|    -      0
Balance.swift                    | 100%     21| 100%     8|    -      0
Commodity.swift                  | 100%     29| 100%     7|    -      0
Cost.swift                       |47.0%    117|88.9%     9|    -      0
Custom.swift                     | 100%     24| 100%    10|    -      0
Event.swift                      | 100%     24| 100%     9|    -      0
Flag.swift                       | 100%      1| 100%     1|    -      0
Inventory.swift                  |98.4%    129|96.6%    29|    -      0
Ledger.swift                     | 100%    189| 100%    66|    -      0
MultiCurrencyAmount.swift        | 100%     60| 100%    14|    -      0
Option.swift                     | 100%     10| 100%     3|    -      0
Price.swift                      | 100%     30| 100%     9|    -      0
Tag.swift                        | 100%     10| 100%     4|    -      0
Transaction.swift                | 100%     70| 100%    13|    -      0
TransactionMetaData.swift        | 100%     26| 100%    12|    -      0
TransactionPosting.swift         | 100%     30| 100%    10|    -      0
=======================================================================
                           Total:|93.4%    982|98.8%   252|    -      0
```

The sed currently used parses the line and function coverage:
```
➜ lcov --list ~/Desktop/cov.txt | sed -n "s/.*Total:|\(.*\)%.*/\1/p"   
93.4%    982|98.8
```

With my fix it only parses the line coverage:
```
➜ lcov --list ~/Desktop/cov.txt | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p"
93.4
```